### PR TITLE
Added JAXB.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,9 @@ lazy val pit = project
     version := "2020102.1.0", // Same version as defined by the pitlauncher bundle
     libraryDependencies ++= Seq(
       "edu.gemini.ocs" %% "edu-gemini-pit-launcher" % version.value,
-      "org.osgi" % "org.osgi.core" % "4.2.0"
+      "org.osgi" % "org.osgi.core" % "4.2.0",
+      "javax.xml.bind" % "jaxb-api" % "2.3.1",
+      "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.1"
     ),
     appName := "Gemini PIT",
     maintainer in Universal := "Gemini Software Group",


### PR DESCRIPTION
This allows us to open programs and print them to XML, but we still are getting some exceptions and I haven't successfully yet exported a program. This happens when I open a program, although the PIT seems to continue to remain responsive:

```
java.lang.NoClassDefFoundError: argonaut/DecodeJson
	at edu.gemini.gsa.query.GsaFileListQuery$.apply(GsaFileListQuery.scala:28)
	at edu.gemini.gsa.client.impl.GsaClientImpl$.<init>(GsaClientImpl.scala:16)
	at edu.gemini.gsa.client.impl.GsaClientImpl$.<clinit>(GsaClientImpl.scala)
	at edu.gemini.pit.ui.robot.GsaRobot$$anonfun$query$1.apply(GsaRobot.scala:17)
	at edu.gemini.pit.ui.robot.GsaRobot$$anonfun$query$1.apply(GsaRobot.scala:16)
	at scala.Option.flatMap(Option.scala:171)
	at edu.gemini.pit.ui.robot.GsaRobot$.query(GsaRobot.scala:16)
	at edu.gemini.pit.ui.robot.ObservationMetaRobot$$anonfun$doRefresh$1$$anonfun$apply$1.apply$mcV$sp(ObservationMetaRobot.scala:189)
	at edu.gemini.pit.ui.robot.ObservationMetaRobot$$anonfun$doRefresh$1$$anonfun$apply$1.apply(ObservationMetaRobot.scala:189)
	at edu.gemini.pit.ui.robot.ObservationMetaRobot$$anonfun$doRefresh$1$$anonfun$apply$1.apply(ObservationMetaRobot.scala:189)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
	at scala.concurrent.impl.ExecutionContextImpl$AdaptedForkJoinTask.exec(ExecutionContextImpl.scala:121)
	at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.lang.ClassNotFoundException: argonaut.DecodeJson
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(Unknown Source)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	... 17 more
```

