### PR TITLE
Add argonaut.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.ipr
+*.iws
 *.class
 *.log
 *.swp

--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,11 @@ lazy val pit = project
   .settings(
     version := "2020102.1.0", // Same version as defined by the pitlauncher bundle
     libraryDependencies ++= Seq(
-      "edu.gemini.ocs" %% "edu-gemini-pit-launcher" % version.value,
-      "org.osgi" % "org.osgi.core" % "4.2.0",
-      "javax.xml.bind" % "jaxb-api" % "2.3.1",
-      "org.glassfish.jaxb" % "jaxb-runtime" % "2.3.1"
+      "edu.gemini.ocs"     %% "edu-gemini-pit-launcher" % version.value,
+      "org.osgi"           %  "org.osgi.core"           % "4.2.0",
+      "javax.xml.bind"     %  "jaxb-api"                % "2.3.1",
+      "org.glassfish.jaxb" %  "jaxb-runtime"            % "2.3.1",
+      "io.argonaut"        %% "argonaut"                % "6.2.2"
     ),
     appName := "Gemini PIT",
     maintainer in Universal := "Gemini Software Group",


### PR DESCRIPTION
Argonaut needs to be explicitly included, it turns out, in order to do GOA checks.