### PR TITLE
Updated version, dmg name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+
 import NativePackagerHelper._
 
 name in ThisBuild := "ocs-osx"
@@ -5,6 +6,11 @@ name in ThisBuild := "ocs-osx"
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 scalaVersion in ThisBuild := "2.11.11"
+
+lazy val pitVersion = settingKey[OcsVersion]("Version for PIT and its [unshared] bundles.")
+
+// Same version as defined in the OCS top-level build.sbt please.
+pitVersion in ThisBuild := OcsVersion("2020B", true, 2, 1, 0)
 
 organization := "edu.gemini"
 
@@ -23,9 +29,9 @@ lazy val pit = project
   .in(file("pit"))
   .enablePlugins(NotarizedDmgPlugin)
   .settings(
-    version := "2020102.1.0", // Same version as defined by the pitlauncher bundle
+    version := pitVersion.value.toString,
     libraryDependencies ++= Seq(
-      "edu.gemini.ocs"     %% "edu-gemini-pit-launcher" % version.value,
+      "edu.gemini.ocs"     %% "edu-gemini-pit-launcher" % pitVersion.value.toOsgiVersion,
       "org.osgi"           %  "org.osgi.core"           % "4.2.0",
       "javax.xml.bind"     %  "jaxb-api"                % "2.3.1",
       "org.glassfish.jaxb" %  "jaxb-runtime"            % "2.3.1",

--- a/project/NotarizedDmgPlugin.scala
+++ b/project/NotarizedDmgPlugin.scala
@@ -60,7 +60,7 @@ object NotarizedDmgPlugin extends AutoPlugin {
           val projectName     = name.value.replaceAll(" ", "_")
           val notUID          = notarizationUID.value
           val iconFile        = new File("Resources", icon.value)
-          val dmgName         = s"${projectName}_$versionY"
+          val dmgName         = s"${projectName}_${versionY}_macos"
           val dmg             = new File(t, (dmgName + ".dmg"))
           val entitlements =
             Paths.get(getClass.getClassLoader.getResource("entitlements.plist").toURI).toFile
@@ -128,7 +128,7 @@ object NotarizedDmgPlugin extends AutoPlugin {
             )
           }
 
-          val volname = "%s_%s".format(projectName, versionY)
+          val volname = "%s_%s_macos".format(projectName, versionY)
           val dmgname = volname + ".dmg"
           val dest    = new File(t, dmgname)
           if (dest.exists) IO.delete(dest)

--- a/project/OcsVersion.scala
+++ b/project/OcsVersion.scala
@@ -1,0 +1,19 @@
+// Extracted from `ocs` build.
+final case class OcsVersion(semester: String, test: Boolean, xmlCompatibility: Int, serialCompatibility: Int, minor: Int) {
+
+  private val Pat = "(\\d{4})([AB])".r
+  private val Pat(year, half) = semester
+  private val halfDigit = if (half == "A") 0 else 1
+
+  /** Convert to an OSGi-compatible version. */
+  def toOsgiVersion: String =
+    f"${year}%s${halfDigit}%d${xmlCompatibility}%02d.${serialCompatibility}%d.${minor}%d"
+
+  def sourceFileName = "CurrentVersion.java"
+
+  override def toString: String = {
+    val testString = if (test) "-test" else ""
+    s"${semester}${testString}.$xmlCompatibility.$serialCompatibility.$minor"
+  }
+
+}


### PR DESCRIPTION
Updates the build to set the version to the same semester-based value used pre-notarization (e.g., 2020B.2.1.0) and to name the `.dmg` the same as it was pre-notarization.