### PR TITLE
Add `.app` extension

### DIFF
--- a/project/NotarizedDmgPlugin.scala
+++ b/project/NotarizedDmgPlugin.scala
@@ -66,7 +66,7 @@ object NotarizedDmgPlugin extends AutoPlugin {
             Paths.get(getClass.getClassLoader.getResource("entitlements.plist").toURI).toFile
           val log = logger.value
           log.info(s"Creating dmg $applicationName $versionY")
-          val fullName = s"$applicationName $versionY"
+          val fullName = s"$applicationName $versionY.app"
           val dmgPath  = new File(t, fullName)
           if (dmg.exists) IO.delete(dmg)
 


### PR DESCRIPTION
The `.app` extension is required to make the application executable in Catalina. 
